### PR TITLE
Organize items in the list.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,11 +9,11 @@ Please fill out either the individual or corporate Contributor License Agreement
 (CLA).
 
   * If you are an individual writing original source code and you're sure you
-    own the intellectual property, then you'll need to sign an [individual CLA]
-    (https://developers.google.com/open-source/cla/individual).
+    own the intellectual property, then you'll need to sign an [individual
+    CLA](https://developers.google.com/open-source/cla/individual).
   * If you work for a company that wants to allow you to contribute your work,
-    then you'll need to sign a [corporate CLA]
-    (https://developers.google.com/open-source/cla/corporate).
+    then you'll need to sign a [corporate
+    CLA](https://developers.google.com/open-source/cla/corporate).
 
 Follow either of the two links above to access the appropriate CLA and
 instructions for how to sign and return it. Once we receive it, we'll be able to
@@ -33,11 +33,9 @@ Please ensure your pull request adheres to the following guidelines:
 
 - Search previous suggestions before making a new one, as yours may be a
   duplicate.
-- Make sure the list is useful before submitting. That implies it has enough
-  content and every item has a good succinct description.
 - Make an individual pull request for each suggestion.
 - Use [title-casing](http://titlecapitalization.com) (AP style).
-- Use the following format: `[List Name](link)`
+- Use the following format: `[Item Name](link) Description text.`
 - Link additions should be added to the bottom of the relevant category.
 - New categories or improvements to the existing categorization are welcome.
 - Check your spelling and grammar.

--- a/README.md
+++ b/README.md
@@ -11,15 +11,17 @@ trial](https://cloud.google.com/free-trial/) to try it out.
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
-- [Google Cloud Vision](#google-cloud-vision)
+- [Samples](#samples)
 - [Platforms](#platforms)
-- [License](#license)
-- [Contributing](#contributing)
 - [Other Awesome Lists](#other-awesome-lists)
+- [About This Document](#about-this-document)
+  - [License](#license)
+  - [Disclaimer](#disclaimer)
+  - [Contributing](#contributing)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-## [Google Cloud Vision](https://cloud.google.com/vision/)
+## Samples
 
 - [Bot for Facebook Messenger](https://github.com/jshin49/fb-vision-bot) This
   bot uses the Cloud Vision API to detect faces, labels, landmarks, logos,
@@ -32,26 +34,6 @@ trial](https://cloud.google.com/free-trial/) to try it out.
   Slack integration, running on Google Cloud Platform.
 
 
-## License
-
-[![Creative Commons License](https://i.creativecommons.org/l/by/4.0/88x31.png)](http://creativecommons.org/licenses/by/4.0/)
-
-This work is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/).
-
-
-## Disclaimer
-
-This list is not an official Google product.  Links on this list also are not
-necessarily to official Google products.
-
-
-## Contributing
-
-If you have found or built something awesome that uses the Google Cloud
-Platform, please follow the instructions in [CONTRIBUTING.md](CONTRIBUTING.md)
-to get it included here.
-
-
 ## Other Awesome Lists
 
 - [Awesome](https://github.com/sindresorhus/awesome) - The awesome for awesomes.
@@ -60,3 +42,24 @@ to get it included here.
 - [Awesome Kubernetes](https://github.com/ramitsurana/awesome-kubernetes).
 - [Awesome TensorFlow](https://github.com/jtoy/awesome-tensorflow).
 
+
+## About This Document
+
+### License
+
+[![Creative Commons License](https://i.creativecommons.org/l/by/4.0/88x31.png)](http://creativecommons.org/licenses/by/4.0/)
+
+This work is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/).
+
+
+### Disclaimer
+
+This list is not an official Google product.  Links on this list also are not
+necessarily to official Google products.
+
+
+### Contributing
+
+If you have found or built something awesome that uses the Google Cloud
+Platform, please follow the instructions in [CONTRIBUTING.md](CONTRIBUTING.md)
+to get it included here.


### PR DESCRIPTION
Rather than using the product name, organize by the kind of content.
Currently: Samples, Platforms, and Awesome Lists.

Also, moves the License / Disclaimer / Contributing to an "About This
Document" section to keep it separate from the rest of the content.