### PR TITLE
fix: ignore dead urls for the CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!--lint ignore no-dead-urls-->
 # Awesome List for Google Cloud Platform [![Awesome](https://awesome.re/badge.svg)](https://awesome.re) ![Lint Awesome List](https://github.com/GoogleCloudPlatform/awesome-google-cloud/workflows/Lint%20Awesome%20List/badge.svg)
 
 A curated list of awesome applications, tools, and resources for [Google Cloud Platform](https://cloud.google.com). Inspired by [other awesome projects](https://github.com/sindresorhus/awesome).


### PR DESCRIPTION
Apologies, I forgot that I had seen this issue before on a number of other awesome lists. This fix will tell the linter to ignore the dead url on the following line of the README