### PR TITLE
docs: remove "list for" from title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--lint ignore no-dead-urls-->
-# Awesome List for Google Cloud Platform [![Awesome](https://awesome.re/badge.svg)](https://awesome.re) ![Lint Awesome List](https://github.com/GoogleCloudPlatform/awesome-google-cloud/workflows/Lint%20Awesome%20List/badge.svg)
+# Awesome Google Cloud Platform [![Awesome](https://awesome.re/badge.svg)](https://awesome.re) ![Lint Awesome List](https://github.com/GoogleCloudPlatform/awesome-google-cloud/workflows/Lint%20Awesome%20List/badge.svg)
 
 A curated list of awesome applications, tools, and resources for [Google Cloud Platform](https://cloud.google.com). Inspired by [other awesome projects](https://github.com/sindresorhus/awesome).
 


### PR DESCRIPTION
Awesome Lists titles generally follow the pattern "Awesome <tool>". Removing the "list for" makes the title more succinct