### PR TITLE
docs: use npx for DocToc regen

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,8 +65,4 @@ Thank you for your suggestions!
 We use [DocToc](https://github.com/thlorenz/doctoc) to maintain the table of
 contents.
 
-    npm install -g doctoc
-
-Command to regenerate table of contents:
-
-    doctoc --title '**Table of Contents**' README.md
+    npx doctoc --title '## Contents' README.md

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ If you are new to Google Cloud Platform, there is a [free trial](https://cloud.g
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 ## Contents
 
 - [General](#general)


### PR DESCRIPTION
- Uses `npx` (installed with Node)
- Regens ToC using DocToc (minus newline)