### PR TITLE
fix: update linter to node.js 18

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: "12.x"
+          node-version: "18.x"
       - run: |
           npm install --global awesome-lint@latest
           awesome-lint


### PR DESCRIPTION
Required here: https://github.com/sindresorhus/awesome-lint/blob/6424cc0949c644931bb9441c4384f5a0a9e78a46/package.json#L16